### PR TITLE
feat: require Owner or Manager role before publishing changes (OP-99)

### DIFF
--- a/apps/interface/src/app/components/tree/ChangesBar.tsx
+++ b/apps/interface/src/app/components/tree/ChangesBar.tsx
@@ -87,13 +87,17 @@ export function ChangesBar() {
             onClick={() => {
               const connectedAddress = walletClient?.account?.address?.toLowerCase()
 
+              // Wallet not yet connected/initialized — don't show an auth error
+              if (!connectedAddress) return
+
               // Collect nodes the connected wallet is NOT owner/manager of
               const notOwned: string[] = []
               for (const [nodeName] of pendingMutations.entries()) {
                 const node = findNode(nodeName)
-                if (!node) continue
-                const nodeOwner = node.owner?.toLowerCase()
-                if (!connectedAddress || !nodeOwner || connectedAddress !== nodeOwner) {
+                // If node is absent from sourceTree (e.g. pending creation) treat it as
+                // unauthorized — there is no owner record to verify against.
+                const nodeOwner = node?.owner?.toLowerCase()
+                if (!nodeOwner || connectedAddress !== nodeOwner) {
                   notOwned.push(nodeName)
                 }
               }

--- a/apps/interface/src/components/dialogs/not-authorized-dialog.tsx
+++ b/apps/interface/src/components/dialogs/not-authorized-dialog.tsx
@@ -12,7 +12,7 @@ interface NotAuthorizedDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   /**
-   * The list of ENS node names the connected wallet is not authorised to edit.
+   * The list of ENS node names the connected wallet is not authorized to edit.
    */
   unauthorizedNodes: string[]
 }


### PR DESCRIPTION
## Summary

Closes OP-99.

When a user attempts to **Publish Changes** (clicks "Apply Changes" in the floating bar), the connected wallet is now checked against the `owner` field of each node with pending mutations before the publish dialog is opened.

If the wallet is not the Owner or Manager of any of the affected nodes, a clear **Not Authorized** error dialog is shown, listing the specific node names and instructing the user to switch wallets.

## What changed

### New file: `apps/interface/src/components/dialogs/not-authorized-dialog.tsx`
- Reusable error dialog that accepts a list of unauthorized node names
- Red shield icon header, clear explanation of the Owner/Manager requirement
- Lists each unauthorized node in a styled panel
- "Switch wallet" guidance in the footer

### Modified: `apps/interface/src/app/components/tree/ChangesBar.tsx`
- Added state for `unauthorizedNodes` and `isNotAuthorizedOpen`
- Before opening `ApplyChangesDialog`, iterates pending mutations and compares `node.owner.toLowerCase()` against `walletClient.account.address.toLowerCase()`
- If any nodes fail the check → shows `NotAuthorizedDialog` instead
- Also fixed pre-existing biome lint issues: `type="button"` on bare `<button>` elements, self-closing empty elements

## How the check works

`node.owner` is derived from `wrappedOwnerId ?? ownerId` in the subgraph — the effective manager who can set records for that node. This covers both the ENS Owner (unwrapped names) and the NameWrapper Owner (wrapped names).

## Testing
- Build: ✅ `pnpm build` passes
- Lint: ✅ `biome check` clean on changed files
