### PR TITLE
feat(skill): print SKILL.md content, let agent decide placement

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -10,7 +10,7 @@ if (isRootHelp) {
 CLI for registering AI agents on ENS using ERC-8004 (v2.0).
 
 Usage:
-  ens-metadata skill [--install]
+  ens-metadata skill
 
   ens-metadata registration-file template
   ens-metadata registration-file validate <file.json>

--- a/packages/cli/src/commands/skill.tsx
+++ b/packages/cli/src/commands/skill.tsx
@@ -1,24 +1,14 @@
-import { copyFileSync, existsSync, readFileSync } from 'node:fs'
-import { dirname, join, resolve } from 'node:path'
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { Text, useApp } from 'ink'
+import { Text } from 'ink'
 import React from 'react'
-import { z } from 'zod'
 
-export const description = 'Print or install SKILL.md guide'
-
-export const options = z.object({
-  install: z.boolean().default(false).describe('Copy SKILL.md to the current working directory'),
-})
-
-type Props = {
-  options: z.infer<typeof options>
-}
+export const description = 'Print the SKILL.md guide for this CLI'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
 function getSkillMdPath(): string {
-  // When built: dist/commands/skill.js → root is ../../
   const candidates = [
     join(__dirname, '../../SKILL.md'),
     join(__dirname, '../SKILL.md'),
@@ -30,31 +20,11 @@ function getSkillMdPath(): string {
   throw new Error('SKILL.md not found in package')
 }
 
-export default function Skill({ options: { install } }: Props) {
-  const { exit } = useApp()
-  const [output, setOutput] = React.useState<string>('')
-  const [error, setError] = React.useState<string | null>(null)
-
-  React.useEffect(() => {
-    try {
-      const skillPath = getSkillMdPath()
-      const content = readFileSync(skillPath, 'utf8')
-
-      if (install) {
-        const dest = resolve(process.cwd(), 'SKILL.md')
-        copyFileSync(skillPath, dest)
-        setOutput(`✅ SKILL.md copied to ${dest}`)
-      } else {
-        setOutput(content)
-      }
-    } catch (err) {
-      setError((err as Error).message)
-    }
-    exit()
-  }, [exit, install])
-
-  if (error) {
-    return <Text color="red">❌ {error}</Text>
+export default function Skill() {
+  try {
+    const content = readFileSync(getSkillMdPath(), 'utf8')
+    return <Text>{content}</Text>
+  } catch (err) {
+    return <Text color="red">❌ {(err as Error).message}</Text>
   }
-  return <Text>{output}</Text>
 }


### PR DESCRIPTION
## Summary

The `skill` command previously copied `SKILL.md` to the current working directory with `--install`. This was fragile — agent setups vary and there's no reliable way for the CLI to know the correct skills root for a given system.

## Changes

- Removes `--install` and `--dir` flags entirely
- `ens-metadata skill` now just prints the SKILL.md content to stdout
- The calling agent reads it and places the file correctly for its own setup

## Rationale

The agent invoking this command has full context about its workspace layout. Printing the skill and letting it handle placement is simpler, more portable, and doesn't require the CLI to encode assumptions about agent framework conventions.