### PR TITLE
fix: text records can't be added manually (OP-155)

### DIFF
--- a/apps/interface/src/app/components/tree/drawers/EditNodeDrawer.tsx
+++ b/apps/interface/src/app/components/tree/drawers/EditNodeDrawer.tsx
@@ -250,6 +250,21 @@ export function EditNodeDrawer() {
                       }
                     }
 
+                    // Also include keys added via addCustomAttribute that exist in formData
+                    // but not yet persisted to nodeWithEdits.texts
+                    const systemFields = new Set(['schema', 'class'])
+                    const extraKeySet = new Set(extraKeys)
+                    for (const [key, value] of Object.entries(formData)) {
+                      if (
+                        !schemaKeys.has(key) &&
+                        !extraKeySet.has(key) &&
+                        !systemFields.has(key) &&
+                        typeof value === 'string'
+                      ) {
+                        extraKeys.push(key)
+                      }
+                    }
+
                     return (
                       <div>
                         {/* Address fields */}


### PR DESCRIPTION
## Summary

When a user adds a new text record via `+ Record`, the key is added to `formData` via `addCustomAttribute` but never appears in the UI because `extraKeys` was built exclusively from `nodeWithEdits.texts`. Since the new key doesn't exist in `texts` yet (it hasn't been saved), it was silently dropped.

## Changes

- In `EditNodeDrawer.tsx`, extended the `extraKeys` array to also include keys from `formData` that are not in `schemaKeys`, not already in `extraKeys`, not system fields (`schema`, `class`), and have a string value (null means marked for deletion)

## Skipped / Deferred

None.

## Linear

Closes OP-155
