### PR TITLE
Add SessionStart hook for Claude Code on the web

### DIFF
--- a/.claude/hooks/setup.sh
+++ b/.claude/hooks/setup.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# SessionStart hook — prepares the workspace for Claude Code on the web.
+# Installs pnpm dependencies and builds the SDK so tests and linters work.
+set -euo pipefail
+
+# Only needed in remote (web) containers, where deps are not pre-installed.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+# SessionStart stdout is injected into the session context; redirect it to
+# stderr so pnpm's output lands in the setup logs instead of the transcript.
+exec 1>&2
+
+cd "${CLAUDE_PROJECT_DIR:-$(pwd)}"
+
+echo "[session-start] Installing workspace dependencies..."
+pnpm install
+
+# The SDK package exports point at dist/, so the CLI and apps — and their
+# vitest suites — can only resolve @ensmetadata/sdk after it is built.
+echo "[session-start] Building @ensmetadata/sdk..."
+pnpm exec turbo run build --filter=@ensmetadata/sdk
+
+echo "[session-start] Workspace ready."

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/setup.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a SessionStart hook (`.claude/hooks/setup.sh`) that prepares the workspace for Claude Code on the web.
- On remote (web) containers it runs `pnpm install` and builds `@ensmetadata/sdk` — which the CLI and apps consume through its `dist/` exports — so tests and linters work in the session. It exits early as a no-op on local machines.
- Registers the hook in `.claude/settings.json`.

## Test plan
- [x] Hook runs end-to-end: `pnpm install` (~20s) + SDK build via `tsup`, exit 0
- [x] Linter works: `biome check packages/sdk/src/index.ts`, exit 0
- [x] Tests work: CLI `vitest run src/tests/uid.test.ts`, 11/11 passed

## Notes
- Runs synchronously — web sessions start only after setup completes, which guarantees dependencies are ready before any test or lint runs. Can switch to async mode for faster startup if preferred.
- Takes effect for all future web sessions once merged into the default branch.

https://claude.ai/code/session_01A6HKQ4t3BBPL13JiAcgN8j

---
_Generated by [Claude Code](https://claude.ai/code/session_01A6HKQ4t3BBPL13JiAcgN8j)_