### PR TITLE
refactor: targeted clean-code pass (dead code, named constants, conditionals)

### DIFF
--- a/apps/identity/src/components/builder/IntentCreator.tsx
+++ b/apps/identity/src/components/builder/IntentCreator.tsx
@@ -14,6 +14,11 @@ import { AlertCircle, Check, Copy, ExternalLink, PencilLine } from 'lucide-react
 import { useEffect, useState } from 'react'
 import type { Hex } from 'viem'
 
+/** How long a signed intent stays valid (10 minutes). */
+const INTENT_EXPIRY_MS = 10 * 60 * 1000
+/** How long the "copied" affordance shows before resetting. */
+const COPY_RESET_MS = 1800
+
 type Phase = 'idle' | 'ens-missing' | 'signing' | 'submitting' | 'success' | 'error'
 
 interface Props {
@@ -78,7 +83,7 @@ export function IntentCreator({ buildConfig, hasContent, onGeneratedChange }: Pr
     try {
       setPhase('signing')
       const configHash = hashConfig(config)
-      const expiry = Date.now() + 10 * 60 * 1000
+      const expiry = Date.now() + INTENT_EXPIRY_MS
       // Intents must be signed from mainnet: the EIP-712 domain pins
       // `chainId: 1` (reverse records live there), and wallets refuse to sign
       // typed data whose domain chain doesn't match the active chain.
@@ -98,7 +103,6 @@ export function IntentCreator({ buildConfig, hasContent, onGeneratedChange }: Pr
 
       setPhase('submitting')
       const body = { address, ensName, config, signature, expiry }
-      console.log('[intent] POST /api/intent body:', JSON.stringify(body, null, 2))
       const { id } = await createIntent(body)
       setShareUrl(`${window.location.origin}/${id}`)
       setPhase('success')
@@ -117,7 +121,7 @@ export function IntentCreator({ buildConfig, hasContent, onGeneratedChange }: Pr
     if (!shareUrl) return
     await navigator.clipboard.writeText(shareUrl)
     setCopied(true)
-    setTimeout(() => setCopied(false), 1800)
+    setTimeout(() => setCopied(false), COPY_RESET_MS)
   }
 
   const handleMakeChanges = () => {

--- a/apps/identity/src/components/wizard/ComposeContext.tsx
+++ b/apps/identity/src/components/wizard/ComposeContext.tsx
@@ -26,6 +26,12 @@ type Ens = ReturnType<typeof useVerifyEns>
 type Socials = ReturnType<typeof useSocialAccounts>
 type Attestation = ReturnType<typeof useAttestationFlow>
 
+/**
+ * Upper bound on how many indices we probe per array attribute when
+ * pre-loading existing on-chain records (`attr[0]..attr[19]`). Reads are
+ * batched, so this just caps the request fan-out; reconstruction stops at the
+ * first empty index.
+ */
 const MAX_ARRAY_PROBE = 20
 
 interface ComposeContextValue {
@@ -274,14 +280,10 @@ export function ComposeProvider({ config, schema, keyLabels, children }: Provide
 
   const requiredAccountsLinked = requiredPlatforms.every(socials.isLinked)
 
+  const walletReady = !!walletClient && !!address
+  const formReady = attrsLoaded && missingRequiredAttrs.length === 0
   const canCreate =
-    ens.confirmed &&
-    !!walletClient &&
-    !!address &&
-    missingRequiredAttrs.length === 0 &&
-    requiredAccountsLinked &&
-    attrsLoaded &&
-    !attestation.isSigning
+    ens.confirmed && walletReady && formReady && requiredAccountsLinked && !attestation.isSigning
 
   const previewLabel = (() => {
     switch (attestation.signPhase) {

--- a/apps/identity/src/hooks/use-publish-flow.ts
+++ b/apps/identity/src/hooks/use-publish-flow.ts
@@ -109,7 +109,12 @@ export function usePublishFlow(intentId: string) {
 
       setPhase('confirming')
       await publicClient.waitForTransactionReceipt({ hash, confirmations: 2 })
-      if (sessionId) await evictSession(sessionId).catch(() => {})
+      if (sessionId) {
+        // Best-effort cleanup; don't fail the publish, but don't hide failures either.
+        await evictSession(sessionId).catch((err) =>
+          console.warn('[publish] session eviction failed:', err),
+        )
+      }
       setPhase('done')
     } catch (err) {
       setError(friendlyError(err))


### PR DESCRIPTION
A small, **behavior-preserving** demonstration of applying [clean-code-typescript](https://github.com/labs42io/clean-code-typescript) to this repo. The repo already enforces most of the guide automatically (Biome formatting/imports/naming, strict TS + `verbatimModuleSyntax`, functional style, `as const` unions, discriminated-union results), so this targets only the handful of *real* deviations where the fix is a clear, low-risk win.

### Changes (all `apps/identity`)
- **Remove dead code** — deleted a stray debug `console.log('[intent] POST …')` that dumped the full request body to the console.
- **Use searchable names** — extracted magic time literals to `INTENT_EXPIRY_MS` / `COPY_RESET_MS`; added a JSDoc explaining why `MAX_ARRAY_PROBE` is 20.
- **Encapsulate conditionals** — split the 7-clause `canCreate` expression into named predicates (`walletReady`, `formReady`).
- **Don't ignore rejected promises** — gave the silently-swallowed `evictSession(...).catch(() => {})` a contextual `console.warn` (still non-fatal).

### Deliberately NOT done (respecting house style)
Enums (repo uses `as const`), class conversions, `import type`/non-null-assertion enforcement (Biome opts out intentionally), repo-wide path aliases, decomposing `ComposeContext`/scripts, the `computeDelta` flag param. Also skipped three findings verified as non-issues: `estimate-cost.ts` (already clean), the `session-store` "mutation" (safe under single-threaded Durable Objects), and the health-endpoint catch (already logs + degrades intentionally).

### Verification
- `pnpm exec biome check` on changed files — clean
- `pnpm --dir apps/identity exec tsc --noEmit` — 0 errors
- No behavioral change to exercise (no test suite in `apps/identity`)